### PR TITLE
Fix docker compose ch5

### DIFF
--- a/ch05/docker-compose-ch05-arm64.yaml
+++ b/ch05/docker-compose-ch05-arm64.yaml
@@ -7,7 +7,8 @@ services:
     hostname: deltalake-quickstart
     container_name: deltalake-quickstart
     volumes:
-      - ${PWD}:/opt/spark/work-dir/ch6
+      - ${PWD}:/opt/spark/work-dir/ch5
+      - ${PWD}/../datasets:/opt/spark/work-dir/ch5
     ports:
       - 8888-8889:8888-8889
     restart: always

--- a/ch05/docker-compose-ch05.yaml
+++ b/ch05/docker-compose-ch05.yaml
@@ -7,7 +7,8 @@ services:
     hostname: deltalake-quickstart
     container_name: deltalake-quickstart
     volumes:
-      - ${PWD}:/opt/spark/work-dir/ch6
+      - ${PWD}:/opt/spark/work-dir/ch5
+      - ${PWD}/../datasets:/opt/spark/work-dir/ch5
     ports:
       - 8888-8889:8888-8889
     restart: always


### PR DESCRIPTION
- Fixed the volume naming issue in Chapter 5 (ch5), where it was incorrectly referencing Chapter 6 (ch6).
- Added the datasets directory as a volume in Docker.
- Included the dataset referenced in Chapter 5 (source: [NYC TLC Trip Record Data](https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page)).